### PR TITLE
Updated menu base styles to allow the widget control overlay

### DIFF
--- a/css/menu.css
+++ b/css/menu.css
@@ -12,7 +12,7 @@ body.disableScroll {
   overflow: hidden;
 }
 
-[data-fl-widget-instance][data-widget-package="com.fliplet.menu.bottom-bar"] {
+[data-fl-widget-instance][data-type="menu"] {
   position: fixed !important;
   left: 0;
   right: 0;

--- a/css/menu.css
+++ b/css/menu.css
@@ -17,10 +17,15 @@ body.disableScroll {
   left: 0;
   right: 0;
   bottom: 0;
+  height: 65px;
   z-index: 1009;
 }
 
 .fl-bottom-bar-menu-holder {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
   display: block;
   color: rgba(255,255,255,0.5);
   padding: 0;

--- a/css/menu.css
+++ b/css/menu.css
@@ -12,12 +12,15 @@ body.disableScroll {
   overflow: hidden;
 }
 
-.fl-bottom-bar-menu-holder {
-  position: fixed;
+[data-fl-widget-instance][data-widget-package="com.fliplet.menu.bottom-bar"] {
+  position: fixed !important;
   left: 0;
   right: 0;
   bottom: 0;
   z-index: 1009;
+}
+
+.fl-bottom-bar-menu-holder {
   display: block;
   color: rgba(255,255,255,0.5);
   padding: 0;


### PR DESCRIPTION
- Some style changes made to allow the orange overlay on top

<img width="357" alt="Screenshot 2019-06-10 at 11 44 27" src="https://user-images.githubusercontent.com/7046481/59190653-2b930280-8b75-11e9-9eaf-727f1889cde4.png">

If the user clicks on the orange overlay, or the cog wheel icon, the menu settings will open on the right side.
If the user clicks on the brush icon, the appearance settings for the menu will open on the right side.