### PR TITLE
fixed not scrollable links if them to many on the screen

### DIFF
--- a/css/menu.css
+++ b/css/menu.css
@@ -46,6 +46,9 @@ body.disableScroll {
 [data-has-notch] .fl-bottom-bar-menu-holder.expanded,
 .fl-bottom-bar-menu-holder.expanded ul {
   transform: translate3d(0, 0, 0);
+  overflow-y: scroll;
+  right: -30px;
+  max-height: 100%;
 }
 
 [data-has-notch] .fl-bottom-bar-menu-holder {

--- a/css/menu.css
+++ b/css/menu.css
@@ -46,9 +46,8 @@ body.disableScroll {
 [data-has-notch] .fl-bottom-bar-menu-holder.expanded,
 .fl-bottom-bar-menu-holder.expanded ul {
   transform: translate3d(0, 0, 0);
-  overflow-y: scroll;
-  right: -30px;
-  max-height: 100%;
+  overflow-y: auto;
+  height: 100%;
 }
 
 [data-has-notch] .fl-bottom-bar-menu-holder {
@@ -286,4 +285,13 @@ body.disableScroll {
 
 [data-has-notch] .slide-over {
   padding-bottom: calc(85px + 34px);
+}
+
+/* Override global style for hide scroll if content does not take full screen */
+body.fl-with-bottom-menu.fl-menu-bottom-bar {
+  min-height: 95%;
+}
+
+.hide-scroll {
+  overflow: hidden;
 }

--- a/js/menu.js
+++ b/js/menu.js
@@ -69,7 +69,15 @@ function init() {
   // Show more, when available
   $menuElement.on('click', 'li[data-show-more]', function() {
     var $parent = $(this).parents('.fl-bottom-bar-menu-holder');
+    var menuHeight = $parent[0].clientHeight;
+    var deviceHeight = window.document.documentElement.clientHeight;
     $parent.toggleClass('expanded');
+
+    // Prevent scrolling content when menu is opened
+    $('body.fl-with-bottom-menu.fl-menu-bottom-bar').toggleClass('hide-scroll');
+
+    // Set height depend on device and content height to prevent stretching the menu to full screen
+    $parent.height(menuHeight > deviceHeight ? '100%' : 'unset');
   });
 
   $menuElement.on('click', '.fl-bottom-bar-menu-holder li:not([data-show-more])', function() {


### PR DESCRIPTION
@squallstar @tonytlwu 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/4828
## Description
Added css rules to have an opportunity to scroll menu-bottom in all devices.
## Screenshots/screencasts
https://cl.ly/23c7fd6768f7
## Backward compatibility
This change is fully backward compatible.