### PR TITLE
Icons now visible if "All screens" option is selected

### DIFF
--- a/build.html
+++ b/build.html
@@ -18,11 +18,13 @@
           {{/compare}}
           <li data-fl-navigate='{{{page.action}}}' data-page-id="{{page.pageId}}">
             <div class="fl-bottom-bar-icon-holder">
-              {{#if page.icon}}
               <div class="fl-menu-icon">
+                {{#if page.icon}}
                 <i class="{{page.icon}}"></i>
+                {{else}}
+                <i class="fa fa-circle"></i>
+                {{/if}}
               </div>
-              {{/if}}
               <div class="fl-menu-title">
                 <span>{{page.label}}</span>
               </div>
@@ -31,11 +33,13 @@
         {{else}}
         <li data-fl-navigate='{{{page.action}}}' data-page-id="{{page.pageId}}">
           <div class="fl-bottom-bar-icon-holder">
-            {{#if page.icon}}
             <div class="fl-menu-icon">
+              {{#if page.icon}}
               <i class="{{page.icon}}"></i>
+              {{else}}
+              <i class="fa fa-circle"></i>
+              {{/if}}
             </div>
-            {{/if}}
             <div class="fl-menu-title">
               <span>{{page.label}}</span>
             </div>
@@ -64,11 +68,13 @@
           {{/compare}}
           <li data-fl-navigate='{{{page.action}}}' data-page-id="{{page.pageId}}">
             <div class="fl-bottom-bar-icon-holder">
-              {{#if page.icon}}
               <div class="fl-menu-icon">
+                {{#if page.icon}}
                 <i class="{{page.icon}}"></i>
+                {{else}}
+                <i class="fa fa-circle"></i>
+                {{/if}}
               </div>
-              {{/if}}
               <div class="fl-menu-title">
                 <span>{{page.label}}</span>
               </div>
@@ -77,11 +83,13 @@
         {{else}}
         <li data-fl-navigate='{{{page.action}}}' data-page-id="{{page.pageId}}">
           <div class="fl-bottom-bar-icon-holder">
-            {{#if page.icon}}
             <div class="fl-menu-icon">
+              {{#if page.icon}}
               <i class="{{page.icon}}"></i>
+              {{else}}
+              <i class="fa fa-circle"></i>
+              {{/if}}
             </div>
-            {{/if}}
             <div class="fl-menu-title">
               <span>{{page.label}}</span>
             </div>


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5009

## Description
Now if page.icon is undefined, icon will be set to circle.

## Screenshots/screencasts
![bottom icon demo](https://user-images.githubusercontent.com/52824207/70391740-0e82a380-19e1-11ea-8ef8-6d94eae25440.gif)

## Backward compatibility
This change is fully backward compatible.