### PR TITLE
Expanding menu on IE now works correctly

### DIFF
--- a/css/menu.css
+++ b/css/menu.css
@@ -298,3 +298,12 @@ body.disableScroll {
 .hide-scroll {
   overflow: hidden;
 }
+
+/* IE11 layout */
+@media screen and (-ms-high-contrast: none) {
+  .fl-bottom-bar-menu-holder.expanded,
+  [data-has-notch] .fl-bottom-bar-menu-holder.expanded,
+  .fl-bottom-bar-menu-holder.expanded ul {
+    height: auto;
+  }
+}


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5206

## Description
Replaced height: 100% with height: auto.

## Screenshots/screencasts
https://streamable.com/mw5q7n

## Backward compatibility
This change is fully backward compatible.

## Reviewers 
@upplabs-alex-levchenko @YaroslavOvdii