### PR TITLE
CSD-683 [Fix] Don't miss menu items in bottom bar menu on tablet/desktop

### DIFF
--- a/build.html
+++ b/build.html
@@ -16,7 +16,7 @@
             </div>
           </li>
           {{/compare}}
-          <li class="focus-outline {{#compare pageIndex '>' 7}}hidden{{/compare}}" data-fl-navigate='{{{page.action}}}' data-page-id="{{page.pageId}}" tabindex="0">
+          <li class="focus-outline {{#compare pageIndex '>=' 7}}hidden{{/compare}}" data-hidden data-fl-navigate='{{{page.action}}}' data-page-id="{{page.pageId}}" tabindex="0">
             <div class="fl-bottom-bar-icon-holder">
               <div class="fl-menu-icon">
                 {{#if page.icon}}


### PR DESCRIPTION
@sofiiakvasnevska
## Issue
CSD-683 https://weboo.atlassian.net/browse/CSD-683
## Description
Missing data-hidden attribute for tablet template caused hiding menu items with index over 7
## Screenshots/screencasts
https://monosnap.com/file/gq1jAy1FOKsQ66rIY2nUNYbJgYt0Ue
## Backward compatibility
This change is fully backward compatible.
## Reviewers 
@upplabs-alex-levchenko @AndrRyaz @YaroslavOvdii