### PR TITLE
PS-1641 [FIX] Hide bottom menu when native keyboard opened

### DIFF
--- a/css/menu.css
+++ b/css/menu.css
@@ -29,6 +29,10 @@ body.disableScroll {
   z-index: 1009;
 }
 
+body.fl-bottom-bar-keyboard-visible [data-fl-widget-instance][data-type="menu"] {
+  display: none;
+}
+
 .fl-bottom-bar-menu-holder {
   position: fixed;
   left: 0;
@@ -41,6 +45,10 @@ body.disableScroll {
   transform: translate3d(0, -65px, 0);
   transform: translate3d(0, calc(-65px - env(safe-area-inset-bottom)), 0);
   transition: transform 0.2s ease-out;
+}
+
+body.fl-bottom-bar-keyboard-visible .fl-bottom-bar-menu-holder {
+  display: none;
 }
 
 .fl-bottom-bar-menu-holder ul {

--- a/js/menu.js
+++ b/js/menu.js
@@ -28,37 +28,39 @@ function attachKeyboardHandlers() {
     return;
   }
 
+  if (!window.visualViewport) {
+    return;
+  }
+
   var $body = $('body');
   var isKeyboardVisible = false;
-  var initialViewportHeight = window.visualViewport ? window.visualViewport.height : window.innerHeight;
+  var initialViewportHeight = window.visualViewport.height;
 
-  if (window.visualViewport) {
-    /**
-     * Handles viewport resize and scroll events to detect keyboard visibility
-     * @private
-     */
-    var viewportHandler = function() {
-      var viewportHeight = window.visualViewport.height;
+  /**
+   * Handles viewport resize and scroll events to detect keyboard visibility
+   * @private
+   */
+  var viewportHandler = function() {
+    var viewportHeight = window.visualViewport.height;
 
-      // If viewport height is significantly smaller than initial height, keyboard is visible
-      // Threshold of 150px accounts for device variations
-      var heightDifference = initialViewportHeight - viewportHeight;
-      var keyboardVisible = heightDifference > 150;
+    // If viewport height is significantly smaller than initial height, keyboard is visible
+    // Threshold of 150px accounts for device variations
+    var heightDifference = initialViewportHeight - viewportHeight;
+    var keyboardVisible = heightDifference > 150;
 
-      if (keyboardVisible && !isKeyboardVisible) {
-        isKeyboardVisible = true;
-        $body.addClass('fl-bottom-bar-keyboard-visible');
-      } else if (!keyboardVisible && isKeyboardVisible) {
-        isKeyboardVisible = false;
-        $body.removeClass('fl-bottom-bar-keyboard-visible');
-        // Update initial height when keyboard is fully hidden
-        initialViewportHeight = viewportHeight;
-      }
-    };
+    if (keyboardVisible && !isKeyboardVisible) {
+      isKeyboardVisible = true;
+      $body.addClass('fl-bottom-bar-keyboard-visible');
+    } else if (!keyboardVisible && isKeyboardVisible) {
+      isKeyboardVisible = false;
+      $body.removeClass('fl-bottom-bar-keyboard-visible');
+      // Update initial height when keyboard is fully hidden
+      initialViewportHeight = viewportHeight;
+    }
+  };
 
-    window.visualViewport.addEventListener('resize', viewportHandler);
-    window.visualViewport.addEventListener('scroll', viewportHandler);
-  }
+  window.visualViewport.addEventListener('resize', viewportHandler);
+  window.visualViewport.addEventListener('scroll', viewportHandler);
 }
 
 function init() {

--- a/js/menu.js
+++ b/js/menu.js
@@ -24,11 +24,7 @@ function highlightItemByIndex(index) {
  * @returns {void}
  */
 function attachKeyboardHandlers() {
-  if (!Fliplet.Env.is('native')) {
-    return;
-  }
-
-  if (!window.visualViewport) {
+  if (!Fliplet.Env.is('native') || !window.visualViewport) {
     return;
   }
 

--- a/js/menu.js
+++ b/js/menu.js
@@ -1,6 +1,10 @@
 var $menuElement = $('[data-name="Bottom icon bar"]');
 var menuInstanceId = $menuElement.data('id');
 
+/**
+ * Highlights a menu item by its index position
+ * @param {number} index - Zero-based index of the menu item to highlight
+ */
 function highlightItemByIndex(index) {
   $('.fl-bottom-bar-menu-holder')
     .each(function() {
@@ -10,8 +14,57 @@ function highlightItemByIndex(index) {
     });
 }
 
+/**
+ * Attaches keyboard visibility handlers to hide the bottom bar menu when keyboard appears on native devices
+ *
+ * This function uses the Visual Viewport API to detect when the native keyboard is shown or hidden.
+ * When the keyboard is visible, it adds the 'fl-bottom-bar-keyboard-visible' class to the body element,
+ * which triggers CSS rules to hide the bottom menu.
+ *
+ * @returns {void}
+ */
+function attachKeyboardHandlers() {
+  if (!Fliplet.Env.is('native')) {
+    return;
+  }
+
+  var $body = $('body');
+  var isKeyboardVisible = false;
+  var initialViewportHeight = window.visualViewport ? window.visualViewport.height : window.innerHeight;
+
+  if (window.visualViewport) {
+    /**
+     * Handles viewport resize and scroll events to detect keyboard visibility
+     * @private
+     */
+    var viewportHandler = function() {
+      var viewportHeight = window.visualViewport.height;
+
+      // If viewport height is significantly smaller than initial height, keyboard is visible
+      // Threshold of 150px accounts for device variations
+      var heightDifference = initialViewportHeight - viewportHeight;
+      var keyboardVisible = heightDifference > 150;
+
+      if (keyboardVisible && !isKeyboardVisible) {
+        isKeyboardVisible = true;
+        $body.addClass('fl-bottom-bar-keyboard-visible');
+      } else if (!keyboardVisible && isKeyboardVisible) {
+        isKeyboardVisible = false;
+        $body.removeClass('fl-bottom-bar-keyboard-visible');
+        // Update initial height when keyboard is fully hidden
+        initialViewportHeight = viewportHeight;
+      }
+    };
+
+    window.visualViewport.addEventListener('resize', viewportHandler);
+    window.visualViewport.addEventListener('scroll', viewportHandler);
+  }
+}
+
 function init() {
   $('body').addClass('fl-menu-bottom-bar');
+
+  attachKeyboardHandlers();
 
   // Add exit app link
   Fliplet.Hooks.on('addExitAppMenuLink', function() {


### PR DESCRIPTION
### Product areas affected

Menu -> Bottom Icon Bar

### What does this PR do?

This PR implements Visual Viewport API-based keyboard detection that automatically hides bottom menus when the keyboard is shown on native devices, and restores them when the keyboard is dismissed.

### JIRA ticket

[PS-1641](https://weboo.atlassian.net/browse/PS-1641)

[PS-1641]: https://weboo.atlassian.net/browse/PS-1641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ