### PR TITLE
PS-1939: Preserve logout items in master-page DOM cleanup (#51)

### DIFF
--- a/js/menu.js
+++ b/js/menu.js
@@ -76,9 +76,24 @@ function init() {
     $menuElement.find('.fl-bottom-bar-menu-holder li[data-page-id]').each(function() {
       var pageId = $(this).attr('data-page-id');
 
-      if (pageId && masterPageIds[pageId]) {
-        $(this).remove();
+      if (!pageId || !masterPageIds[pageId]) {
+        return;
       }
+
+      // Preserve logout items whose target screen happens to be a master page (PS-1939)
+      var nav = {};
+
+      try {
+        nav = JSON.parse($(this).attr('data-fl-navigate') || '{}');
+      } catch (e) {
+        // Malformed JSON — fall through and remove
+      }
+
+      if (nav.action === 'logout') {
+        return;
+      }
+
+      $(this).remove();
     });
   });
 


### PR DESCRIPTION
The PS-1810 cleanup pass removes menu items whose data-page-id matches a masterPageId. When a Log Out item targets a master page, it was being removed too, causing it to flash on screen and disappear after the deferred Fliplet().then() cleanup ran.

Skip items whose data-fl-navigate action is 'logout' so they survive the master-page deduplication.